### PR TITLE
fix: bug related to flank function when width is negative

### DIFF
--- a/src/genomicranges/GenomicRanges.py
+++ b/src/genomicranges/GenomicRanges.py
@@ -490,7 +490,7 @@ class GenomicRanges(BiocFrame):
                 if width >= 0:
                     tstart = all_starts[idx] - abs(width) if sf else all_ends[idx] + 1
                 else:
-                    tstart = all_starts[idx] if sf else all_ends[idx] + abs(width) + 1
+                    tstart = all_starts[idx] if sf else all_ends[idx] + width + 1
 
             new_starts.append(tstart)
             new_ends.append(tstart + (width * (2 if both else 1) - 1))


### PR DESCRIPTION
Fix a bug related to the `flank` function according to [IRanges' implementation](https://github.com/Bioconductor/IRanges/blob/6aa73ac2f6c0a5778068fb2165e7a0c9d17da107/R/intra-range-methods.R#LL344C20-L344C20)