### PR TITLE
Convert `seqnames` and `strand` for generic use when exporting as dataframe

### DIFF
--- a/src/genomicranges/GenomicRanges.py
+++ b/src/genomicranges/GenomicRanges.py
@@ -1043,8 +1043,8 @@ class GenomicRanges:
         import pandas as pd
 
         _rdf = self._ranges.to_pandas()
-        _rdf["seqnames"] = self._seqnames
-        _rdf["strand"] = self._strand
+        _rdf["seqnames"] = self.get_seqnames()
+        _rdf["strand"] = self.get_strand(as_type="list")
 
         if self._names is not None:
             _rdf.index = self._names

--- a/tests/test_gr_methods_basic.py
+++ b/tests/test_gr_methods_basic.py
@@ -89,3 +89,16 @@ def test_export():
 
     assert df is not None
     assert df.shape[0] == len(gr)
+    assert df["seqnames"].tolist() == [
+        "chr1",
+        "chr2",
+        "chr2",
+        "chr2",
+        "chr1",
+        "chr1",
+        "chr3",
+        "chr3",
+        "chr3",
+        "chr3",
+    ]
+    assert df["strand"].tolist() == ["-", "+", "+", "*", "*", "+", "+", "+", "-", "-"]


### PR DESCRIPTION
Fixes: #81 