### PR TITLE
docs: tweak readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ import biobear as bb
 
 session = bb.new_session()
 
-df = session.read_gtf_file("python/tests/data/test.gtf").to_polars()
+df = session.read_gtf_file("path/to/test.gtf").to_polars()
 df = df.rename({"seqname": "seqnames", "start": "starts", "end": "ends"})
 
-gg = GenomicRanges.from_polars(dd)
+gg = GenomicRanges.from_polars(df)
 
 # do stuff w/ a genomic ranges
 print(len(gg), len(df))


### PR DESCRIPTION
Fixes an issue with the biobear example in the README caused me from the github issue. On line 42, it should be `df` vs `dd` (I tried to cleanup that example in GH, but left `dd` there).